### PR TITLE
Added bias and modified Ymatrix for MAP computation

### DIFF
--- a/experiments/humanFixedBase/humanThreeLinkSens.m
+++ b/experiments/humanFixedBase/humanThreeLinkSens.m
@@ -55,11 +55,13 @@ ymodel.ny = length(sens.parts);
 ymodel.m  = sum(cell2mat(sens.ndof));
 ymodel.Y  = cell(ymodel.ny, ymodel.NB);
 ymodel.Ys = cell(ymodel.ny, ymodel.NB);
+ymodel.bias  = cell(ymodel.ny, 1);
 
 for i = 1 : ymodel.ny
    ny = ny + 1;
    dy = sens.ndof{i};
    ymodel.labels{ny,1} = sens.labels{i};
+   ymodel.bias{ny,1}   = zeros(dy,1);
    for j = 1 : dmodel.NB
       ymodel.Y{ny,j}   = zeros(dy,26);
       ymodel.Ys{ny,j}  = sparse(zeros(dy,26));
@@ -86,11 +88,15 @@ if ymodel.ny ~= ny || ymodel.m ~= m
    error('Something wrong with the number of sensors')
 end
 
+
+
 for i = 1 : dmodel.NB
    
    ymodel.ny = ymodel.ny + 1;
    ymodel.sizes{ymodel.ny,1} = 6;
    ymodel.labels{ymodel.ny,1} = [dmodel.linkname{i} '_ftx'];
+   ymodel.bias{ymodel.ny,1}= zeros(6,1);
+
    for j = 1 : dmodel.NB
       ymodel.Y{ymodel.ny,j}   = zeros(6,26);
       ymodel.Ys{ymodel.ny,j}  = sparse(zeros(6,26));
@@ -103,6 +109,8 @@ for i = 1 : dmodel.NB
    ymodel.ny = ymodel.ny + 1;
    ymodel.sizes{ymodel.ny,1} = 1; 
    ymodel.labels{ymodel.ny,1} = [dmodel.linkname{i} '_d2q'];
+   ymodel.bias{ymodel.ny,1}= zeros(1,1);
+
    for j = 1 : dmodel.NB
       ymodel.Y{ymodel.ny,j}   = zeros(1,26);
       ymodel.Ys{ymodel.ny,j}  = sparse(zeros(1,26));

--- a/src/@MAP/solveID.m
+++ b/src/@MAP/solveID.m
@@ -52,10 +52,16 @@ y      = obj.IDmeas.y;
 S_Dinv = Sv_inv;
 S_dinv = blkdiag(zeros(size(Sv_inv)), Sw_inv);
 S_Yinv = Sy_inv;
-bY     = zeros(size(y));
 bD     = b;
 muD    = zeros(length(S_dinv), 1);
 
+if isfield(obj.IDsens.sensorsParams, 'bias')
+    bY     = cell2mat(obj.IDsens.sensorsParams.bias);
+else
+    bY     = zeros(size(y));
+end
+    
+    
 % permutations corresponding to the RNEA 
 % I      = [obj.ia; obj.ifB; obj.iF(end:-1:1, 1); obj.itau];
 % J      = [obj.jfx; obj.jd2q; obj.ja; obj.jfB; obj.jF(end:-1:1, 1); obj.jtau];

--- a/src/@deterministicMAPsolver/deterministicMAPsolver.m
+++ b/src/@deterministicMAPsolver/deterministicMAPsolver.m
@@ -18,6 +18,7 @@
 % METHODS
 %       setQ - set the current value for the position q
 %      setDq - set the current value for the velocity dq
+%    setBias - set the current b_Y vector
 %       setY - set the current value for the measurement y
 %
 % Author: Francesco Nori
@@ -28,20 +29,20 @@ classdef deterministicMAPsolver
    properties (SetAccess = protected, GetAccess = public)
       IDstate, IDmeas
    end
-   
+
    properties (SetAccess = protected, GetAccess = public)
       IDmodel %% dynamic model
       IDsens  %% sensor model
       d       %% computed maximum-a-posteriori d
       Sd      %% computed maximum-a-posteriori variance
-      
+
       iDs     %% i-indeces for the sparse representation of D
       jDs     %% j- indeces for the sparse representation of D
       Ds      %% values fot the sparse representation of D
-      
+
       ibs     %% i-indeces for the sparse representation of b
       bs      %% values fot the sparse representation of b
-            
+
       id      %% indices for converting [dx dy] in d
       ia      %% indices for accessing rows of ai   in D
       ifB     %% indices for accessing rows of fBi  in D
@@ -52,21 +53,21 @@ classdef deterministicMAPsolver
       jF      %% indices for accessing cols of fi   in D
       jtau    %% indices for accessing cols of taui in D
       jfx     %% indices for accessing cols of fxi  in D
-      jd2q    %% indices for accessing cols of d2qi in D   
-      
+      jd2q    %% indices for accessing cols of d2qi in D
+
       iLabels %% labels for the the rows in D
       jLabels %% labels for the the cols in D
       iIndex  %% sizes  for the the rows in D
       jIndex  %% sizes  for the the cols in D
    end
-   
+
    properties (SetAccess = protected)
       Xup %% Cell array of mdl.n elements. Xup{i} contains {}^{i}X_{\lambda(i)}
       Xa  %% Cell array of mdl.n elements. Xa{i}  contains {}^{i}X_{0}
-      vJ, v, a, fB, f, fx, d2q, tau, 
+      vJ, v, a, fB, f, fx, d2q, tau,
       % iD, jD
    end
-   
+
    % Class methods
    methods
       function a = deterministicMAPsolver(mdl,sns)
@@ -105,7 +106,7 @@ classdef deterministicMAPsolver
                a.Xup{i}  = zeros(6,6);
                a.Xa{i}   = zeros(6,6);
             end
-            
+
             a   = initSparseMatrixIndices(a);
             a   = initSparseMatrix(a);
             a   = initColumnPermutation(a);
@@ -114,7 +115,7 @@ classdef deterministicMAPsolver
                'model to instantiate deterministicMAPsolver'] )
          end
       end % deterministicMAPsolver
-      
+
       function disp(a)
          % Display a deterministicMAPsolver object
          fprintf('deterministicMAPsolver disp to be implemented! \n')
@@ -122,29 +123,28 @@ classdef deterministicMAPsolver
          %fprintf('Description: %s\nDate: %s\nType: %s\nCurrent Value: $%4.2f\n',...
          %   a.Description,a.Date,a.Type,a.CurrentValue);
       end % disp
-      
-      
-      %SETSTATE Set the model position (q) and velocity (dq)
+
+      %% SETSTATE Set the model position (q) and velocity (dq)
       %   This function sets the position and velocity to be used by the inverse
       %   dynamic solver in following computations.
       %
       %   Genova 6 Dec 2014
       %   Author Francesco Nori
-      
+
       function obj = setState(obj,q,dq)
          [n,m] = size(q);
          if (n ~= obj.IDstate.n) || (m ~= 1)
             error('[ERROR] The input q should be provided as a column vector with model.NB rows');
          end
          obj.IDstate.q = q;
-         
+
          %% Compute transforms with respect to the parent for all links
          % obj.Xup{i} contains {}^{i}X_{\lambda(i)}
          for i = 1 : obj.IDstate.n
             [ XJ, ~ ] = jcalc( obj.IDmodel.modelParams.jtype{i}, q(i) );
             obj.Xup{i} = XJ * obj.IDmodel.modelParams.Xtree{i};
          end
-                  
+
          %% Compute transforms with respect to the base for all links
          % obj.Xa{i} contains {}^{i}X_{0}
          for i = 1:length(obj.IDmodel.modelParams.parent)
@@ -156,13 +156,13 @@ classdef deterministicMAPsolver
                obj.Xa{i} = obj.Xup{i} * obj.Xa{obj.IDmodel.modelParams.parent(i)};
             end
          end
-         
+
          [n,m] = size(dq);
          if (n ~= obj.IDstate.n) || (m ~= 1)
             error('[ERROR] The input dq should be provided as a column vector with model.NB rows');
          end
          obj.IDstate.dq = dq;
-         
+
          %% Compute twist in local frame
          % obj.v(:,i) contains {}^{i}v_i
          for i = 1 : obj.IDstate.n
@@ -173,36 +173,50 @@ classdef deterministicMAPsolver
                obj.v(:,i) = obj.Xup{i}*obj.v(:,obj.IDmodel.modelParams.parent(i)) + obj.vJ(:,i);
             end
          end
-         
+
          %% Update the sparse representation of the matrix D
          obj = updateSparseMatrix(obj);
 
       end % setState
-      
+
+
+
+      %%
       function obj = setY(obj,y)
          [m,n] = size(y);
          if (m ~= obj.IDmeas.m) || (n ~= 1)
             error('[ERROR] The input y should be provided as a column vector with ymodel.m rows');
          end
          obj.IDmeas.y = y;
-      end 
-      
+      end
+
+      %% SETBIAS
+      function obj = setBias(obj,bias)
+          obj.IDsens.sensorsParams.bias = bias;
+      end
+
+
+      %%
       function y = simY(obj, d)
          % fprintf('Calling the deterministicMAPsolver simY method \n');
          y = cell2mat(obj.IDsens.sensorsParams.Y)*d;
-      end 
-      
+
+         if isfield(obj.IDsens.sensorsParams, 'bias')
+            y = y + cell2mat(obj.IDsens.sensorsParams.bias);
+         end
+      end
+
       % obj = solveMAP(obj)
    end
-   
-   % methods 
+
+   % methods
       % obj = initDsubmatrixIndices(obj);
-      % obj = initDsubmatrix(obj);      
+      % obj = initDsubmatrix(obj);
       % obj = updateDsubmatrix(obj);
-     
+
       % obj = initSparseMatrixIndices(obj);
       % obj = initSparseMatrix(obj);
-      % obj = updateSparseMatrix(obj);      
+      % obj = updateSparseMatrix(obj);
    % end
 end % classdef
 

--- a/src/@deterministicMAPsolver/deterministicMAPsolver.m
+++ b/src/@deterministicMAPsolver/deterministicMAPsolver.m
@@ -19,6 +19,7 @@
 %       setQ - set the current value for the position q
 %      setDq - set the current value for the velocity dq
 %    setBias - set the current b_Y vector
+% setYmatrix - set the current Y matrix
 %       setY - set the current value for the measurement y
 %
 % Author: Francesco Nori
@@ -181,13 +182,29 @@ classdef deterministicMAPsolver
 
 
 
-      %%
+      %% 
       function obj = setY(obj,y)
          [m,n] = size(y);
          if (m ~= obj.IDmeas.m) || (n ~= 1)
             error('[ERROR] The input y should be provided as a column vector with ymodel.m rows');
          end
          obj.IDmeas.y = y;
+      end
+
+
+      %% SETMATRIX
+      function obj = setYmatrix(obj,Y)
+          if (iscell(Y))
+              %if is cell we directly copy it
+              obj.IDsens.sensorsParams.Y = Y;
+              obj.IDsens.sensorsParams.Ys = sparse(cell2mat(Y));
+          else
+              %we transform the full matrix into a cell array of matrices
+              %we assume the size of the single cells do not change w.r.t.
+              %the current one
+              obj.IDsens.sensorsParams.Y = mat2cell(Y,cell2mat(obj.IDsens.sensorsParams.sizes)',obj.IDsens.sensorsParams.m * ones(1, obj.IDsens.sensorsParams.NB));
+              obj.IDsens.sensorsParams.Ys = sparse(Y);
+          end
       end
 
       %% SETBIAS

--- a/src/@sensors/sensors.m
+++ b/src/@sensors/sensors.m
@@ -19,7 +19,7 @@ classdef sensors
       m
    end
    
-   properties(SetAccess = private, GetAccess = public)
+   properties(SetAccess = public, GetAccess = public)
       sensorsParams
    end
    


### PR DESCRIPTION
Added possibility to set bias b_y in the computation Yd + b_y = y;
  
Added possibility to set Ymatrix in MAPsolver; it is valid for
- Ymatrix composed only of identity matrices (current situation)
- Ymatrix composed of transform matrices (at the moment only for Ymatrix created manually)

cc @iron76 , @traversaro 